### PR TITLE
feat: 支持远程 URL 格式的媒体文件

### DIFF
--- a/rainbow-fart.el
+++ b/rainbow-fart.el
@@ -133,11 +133,10 @@ If it's nil, the hours remind will not started."
                        (> (- (float-time) rainbow-fart--play-last-time) rainbow-fart-keyword-interval)
                      (setq rainbow-fart--play-last-time (float-time)))))
     (when-let ((uri (rainbow-fart--get-media-uri keyword))
-               (command (cond
-                         ;; ((executable-find "aplay") "aplay")
-                         ((executable-find "mpg123") "mpg123")
-                         ((executable-find "mplayer") "mplayer")
-                         ((executable-find "mpv") "mpv"))))
+               (command (or
+                         (executable-find "mpg123")
+                         (executable-find "mplayer")
+                         (executable-find "mpv"))))
       (setq rainbow-fart--playing t)
       (make-process :name "rainbow-fart"
                     :command `(,command ,uri)

--- a/rainbow-fart.el
+++ b/rainbow-fart.el
@@ -118,7 +118,7 @@ If it's nil, the hours remind will not started."
 (defun rainbow-fart--get-media-uri (keyword)
   "Get media uri based on KEYWORD."
   (when-let ((uris (cdr (assoc keyword rainbow-fart-voice-alist))))
-    (let (uri (nth (random (length uris)) uris))
+    (let ((uri (nth (random (length uris)) uris)))
       (if (url-type (url-generic-parse-url uri))
           uri
         (let ((uri (expand-file-name uri rainbow-fart-voice-directory)))

--- a/rainbow-fart.el
+++ b/rainbow-fart.el
@@ -117,13 +117,13 @@ If it's nil, the hours remind will not started."
 
 (defun rainbow-fart--get-media-uri (keyword)
   "Get media uri based on KEYWORD."
-  (when-let* ((uris (cdr (assoc keyword rainbow-fart-voice-alist)))
-              (uri (nth (random (length uris)) uris)))
-    (if (url-type (url-generic-parse-url uri))
-        uri
-      (let ((uri (expand-file-name uri rainbow-fart-voice-directory)))
-        (when (file-exists-p uri)
-          uri)))))
+  (when-let ((uris (cdr (assoc keyword rainbow-fart-voice-alist))))
+    (let (uri (nth (random (length uris)) uris))
+      (if (url-type (url-generic-parse-url uri))
+          uri
+        (let ((uri (expand-file-name uri rainbow-fart-voice-directory)))
+          (when (file-exists-p uri)
+            uri))))))
 
 
 (defun rainbow-fart--play (keyword)


### PR DESCRIPTION
有些播放器是支持接受URL做参数播放远程媒体文件的，因此配置的
rainbow-fart-voice-alist 可以支持配置媒体文件的 URL